### PR TITLE
fix(remote-module): clone remote module by referenced tag

### DIFF
--- a/internal/services/drivers/version_control/git.go
+++ b/internal/services/drivers/version_control/git.go
@@ -2,6 +2,7 @@ package version_control
 
 import (
 	"fmt"
+	"github.com/go-git/go-git/v5/plumbing"
 	"os"
 	"os/exec"
 	"strings"
@@ -16,7 +17,9 @@ import (
 const (
 	FolderPathFormat = "%s/%s"
 	TempFolderPath   = "%s/temp_clone_path/%s"
+	remoteName       = "origin"
 	GitlabTokenENV   = "GITLAB_TOKEN"
+	GitRefTag        = "refs/tags/%s"
 	GitlabUserENV    = "GITLAB_USER"
 	GithubTokenENV   = "GITHUB_TOKEN"
 	GithubUserENV    = "GITHUB_USER"
@@ -74,23 +77,28 @@ func (g *Git) CloneModules(modules map[string]*RemoteModule, modulesSource strin
 
 func (g *Git) clone(moduleData *RemoteModule, directoryPath string, externalGit bool) error {
 
-	remoteName := "origin"
-	if moduleData.Version != "" {
-		remoteName = moduleData.Version
-	}
-
 	if externalGit {
-		err := exec.Command("git", "clone", moduleData.Url, directoryPath, "--depth", "1", "-o", remoteName).Run()
+		args := []string{"clone", moduleData.Url, directoryPath, "--no-tags", "--single-branch", "--depth", "1", "-o", remoteName}
+		if moduleData.Version != "" {
+			args = append(args, "--branch", moduleData.Version)
+		}
+		err := exec.Command("git", args...).Run()
 		return err
 	}
 	userName, token := g.getGitUserNameAndToken(moduleData.Url)
 
-	_, err := git.PlainClone(directoryPath, false, &git.CloneOptions{
-		URL:        moduleData.Url,
-		Auth:       &http.BasicAuth{Password: token, Username: userName},
-		RemoteName: remoteName,
-		Depth:      1,
-	})
+	cloneOpts := git.CloneOptions{
+		URL:          moduleData.Url,
+		Auth:         &http.BasicAuth{Password: token, Username: userName},
+		RemoteName:   remoteName,
+		SingleBranch: true,
+		Tags:         git.NoTags,
+		Depth:        1,
+	}
+	if moduleData.Version != "" {
+		cloneOpts.ReferenceName = plumbing.ReferenceName(fmt.Sprintf(GitRefTag, moduleData.Version))
+	}
+	_, err := git.PlainClone(directoryPath, false, &cloneOpts)
 
 	return err
 }

--- a/internal/services/drivers/version_control/git_test.go
+++ b/internal/services/drivers/version_control/git_test.go
@@ -1,6 +1,7 @@
 package version_control_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -20,9 +21,16 @@ var ModulesTestPath = map[bool]string{
 	false: "./int-temp-git-test",
 }
 
-var mockBadModules = map[string]*version_control.RemoteModule{
+var mockBadUrl = map[string]*version_control.RemoteModule{
 	TerraCrustModuleName: {
 		Url: "https://github.com/appsflyer/terra-crust/test/bad",
+	},
+}
+
+var mockBadVersion = map[string]*version_control.RemoteModule{
+	NamingModuleName: {
+		Url:     "https://github.com/fajrinazis/terraform-aws-resource-naming.git",
+		Version: "bad-tag",
 	},
 }
 
@@ -34,6 +42,21 @@ func TestCloneAndCleanupExternalGit(t *testing.T) {
 	CloneAndCleanup(t, true)
 }
 
+func CloneAndCleanupModules(modules map[string]*version_control.RemoteModule, externalGit bool) error {
+	log := logger.NewSimple()
+
+	gitDriver := version_control.InitGitProvider(log)
+
+	err := gitDriver.CloneModules(modules, ModulesTestPath[externalGit], externalGit)
+	cErr := gitDriver.CleanModulesFolders(modules, ModulesTestPath[externalGit])
+	if err != nil {
+		if cErr != nil {
+			return fmt.Errorf("failed to clone and cleanup module %v %v", err, cErr)
+		}
+		return err
+	}
+	return nil
+}
 func CloneAndCleanup(t *testing.T, externalGit bool) {
 	var mockModules = map[string]*version_control.RemoteModule{
 		TerraCrustModuleName: {
@@ -41,7 +64,7 @@ func CloneAndCleanup(t *testing.T, externalGit bool) {
 		},
 		NamingModuleName: {
 			Url:     "https://github.com/fajrinazis/terraform-aws-resource-naming.git",
-			Version: "v0.23.1",
+			Version: "v0.3.0",
 		},
 		ZonesModuleName: {
 			Url:  "https://github.com/terraform-aws-modules/terraform-aws-route53.git",
@@ -74,8 +97,8 @@ func CloneAndCleanup(t *testing.T, externalGit bool) {
 		t.Errorf("Clone failed , did not find naming")
 	}
 
-	if len(folders) != 3 {
-		t.Errorf("Expected 3 folder count received %d", len(folders))
+	if len(folders) != 1 {
+		t.Errorf("Expected 1 folder count received %d", len(folders))
 	}
 
 	if err = gitDriver.CleanModulesFolders(mockModules, ModulesTestPath[externalGit]); err != nil {
@@ -112,12 +135,27 @@ func TestFailBadUrlExternalGit(t *testing.T) {
 	FailBadUrl(t, true)
 }
 
+func TestFailBadVersionInternalGit(t *testing.T) {
+	FailBadVersion(t, false)
+}
+
+func TestFailBadVersionExternalGit(t *testing.T) {
+	FailBadVersion(t, true)
+}
+
 func FailBadUrl(t *testing.T, externalGit bool) {
 	t.Parallel()
-	log := logger.NewSimple()
-	gitDriver := version_control.InitGitProvider(log)
 
-	err := gitDriver.CloneModules(mockBadModules, ModulesTestPath[externalGit], externalGit)
+	err := CloneAndCleanupModules(mockBadUrl, externalGit)
+	if err == nil {
+		t.Errorf("expected error received error nil")
+	}
+}
+
+func FailBadVersion(t *testing.T, externalGit bool) {
+	t.Parallel()
+
+	err := CloneAndCleanupModules(mockBadVersion, externalGit)
 	if err == nil {
 		t.Errorf("expected error received error nil")
 	}

--- a/internal/services/drivers/version_control/git_test.go
+++ b/internal/services/drivers/version_control/git_test.go
@@ -97,8 +97,8 @@ func CloneAndCleanup(t *testing.T, externalGit bool) {
 		t.Errorf("Clone failed , did not find naming")
 	}
 
-	if len(folders) != 1 {
-		t.Errorf("Expected 1 folder count received %d", len(folders))
+	if len(folders) != 3 {
+		t.Errorf("Expected 3 folder count received %d", len(folders))
 	}
 
 	if err = gitDriver.CleanModulesFolders(mockModules, ModulesTestPath[externalGit]); err != nil {


### PR DESCRIPTION
Closes #55 

This PR: 
1. fix remote module tagging selection instead of main branch selection
2. supports searching `Version` in tags or in branch